### PR TITLE
[IMP] l10n_fi_business_code: black, isort, prettier

### DIFF
--- a/l10n_fi_business_code/__manifest__.py
+++ b/l10n_fi_business_code/__manifest__.py
@@ -6,7 +6,7 @@
     "version": "14.0.1.0.0",
     "development_status": "Production/Stable",
     "category": "CRM",
-    "website": "https://github.com/OCA/l10n-finland/",
+    "website": "https://github.com/OCA/l10n-finland",
     "author": "Tawasta, Odoo Community Association (OCA)",
     "license": "LGPL-3",
     "application": False,

--- a/l10n_fi_business_code/models/res_partner.py
+++ b/l10n_fi_business_code/models/res_partner.py
@@ -6,7 +6,9 @@ from odoo import api, fields, models
 class ResPartner(models.Model):
     _inherit = "res.partner"
 
-    business_code = fields.Char(string="Business ID",)
+    business_code = fields.Char(
+        string="Business ID",
+    )
 
     same_business_code_partner_id = fields.Many2one(
         "res.partner",

--- a/setup/l10n_fi_business_code/odoo/addons/l10n_fi_business_code
+++ b/setup/l10n_fi_business_code/odoo/addons/l10n_fi_business_code
@@ -1,0 +1,1 @@
+../../../../l10n_fi_business_code

--- a/setup/l10n_fi_business_code/setup.py
+++ b/setup/l10n_fi_business_code/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
The rest of the `l10n_fi_business_code` 14.0 migration. The actual migration commit was pushed to `14.0` accidentally in a5e2a7feb51970a98366757a8b912917411500d6