### PR TITLE
[FIX] account_edi_finvoice: Return proper EDI status from _cancel_invoice_edi_finvoice

### DIFF
--- a/account_edi_finvoice/__manifest__.py
+++ b/account_edi_finvoice/__manifest__.py
@@ -21,7 +21,7 @@
 {
     "name": "Import/Export invoices as Finvoice",
     "summary": "Import/Export Finvoice 3.0 invoices",
-    "version": "18.0.1.0.4",
+    "version": "18.0.1.0.5",
     "category": "Accounting",
     "website": "https://github.com/OCA/l10n-finland",
     "author": "Odoo Community Association (OCA), Futural",

--- a/account_edi_finvoice/models/account_edi_format.py
+++ b/account_edi_finvoice/models/account_edi_format.py
@@ -70,7 +70,7 @@ class AccountEdiFormat(models.Model):
             return super()._cancel_invoice_edi(invoice)
 
         # We could delete EDI documents here
-        return
+        return {invoice: {"success": True}}
 
     def _edi_content_invoice_edi_finvoice(self, invoice):
         xml_string = self.env["ir.qweb"]._render(


### PR DESCRIPTION
## Summary

`_cancel_invoice_edi_finvoice` returned `None` after a successful Finvoice cancellation. The `account_edi` framework expects `_cancel_invoice_edi` handlers to return `{invoice: {"success": True}}` (matching the shape `_post_invoice_edi_finvoice` already uses just above), so the EDI document state could be left inconsistent after cancel.

Replace the bare `return` with `return {invoice: {"success": True}}`.

## Test plan

- [ ] Cancel a posted Finvoice EDI document and verify the `account.edi.document` for the invoice transitions cleanly with no traceback.
- [ ] Confirm `_post_invoice_edi_finvoice` is unaffected (same return-shape contract).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
