### PR TITLE
[REM] account_edi_finvoice: Drop unused line_note dead code

### DIFF
--- a/account_edi_finvoice/__manifest__.py
+++ b/account_edi_finvoice/__manifest__.py
@@ -21,7 +21,7 @@
 {
     "name": "Import/Export invoices as Finvoice",
     "summary": "Import/Export Finvoice 3.0 invoices",
-    "version": "18.0.1.0.4",
+    "version": "18.0.1.0.5",
     "category": "Accounting",
     "website": "https://github.com/OCA/l10n-finland",
     "author": "Odoo Community Association (OCA), Futural",

--- a/account_edi_finvoice/models/account_move.py
+++ b/account_edi_finvoice/models/account_move.py
@@ -210,12 +210,6 @@ class AccountMove(models.Model):
 
             line_values["name"] = line_name
 
-            if not article_name and not default_code:
-                # Comment line
-                # TODO: comment lines not working yet
-                line_values["display_type"] = "line_note"
-                line_values["account_id"] = self.env["account.account"]
-
             line_values["quantity"] = quantity
 
             unit_code = edi_format._find_attribute(


### PR DESCRIPTION
## Summary

Remove the unused/buggy comment-line block in `_import_finvoice`:

```python
if not article_name and not default_code:
    # Comment line
    # TODO: comment lines not working yet
    line_values["display_type"] = "line_note"
    line_values["account_id"] = self.env["account.account"]
```

The TODO admits "comment lines not working yet", and `account_id = self.env["account.account"]` assigns an empty recordset, which is broken on the Odoo side. The branch is also unreachable in practice because every Finvoice `InvoiceRow` is required to have at least one of `ArticleName`, `ArticleDescription` or `BuyerArticleIdentifier` (used as `default_code`) — by that point in the flow `article_name` is filled from any of those fallbacks.

## Test plan

- [ ] Import a regular Finvoice 3.0 invoice (no comment-only rows) — line creation unchanged.
- [ ] Import an invoice that contains a row with no `ArticleName`, no `ArticleDescription`, no `BuyerArticleIdentifier` and no `RowFreeText` (rare but possible) — currently this would also fail under the removed branch (empty recordset assignment), so behavior changes from "broken" to "row simply not created with article info". Acceptable until proper comment-line handling is implemented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
