### PR TITLE
[IMP] account_edi_finvoice: Set company and move_type context up-front

### DIFF
--- a/account_edi_finvoice/__manifest__.py
+++ b/account_edi_finvoice/__manifest__.py
@@ -21,7 +21,7 @@
 {
     "name": "Import/Export invoices as Finvoice",
     "summary": "Import/Export Finvoice 3.0 invoices",
-    "version": "18.0.1.0.4",
+    "version": "18.0.1.0.5",
     "category": "Accounting",
     "website": "https://github.com/OCA/l10n-finland",
     "author": "Odoo Community Association (OCA), Futural",

--- a/account_edi_finvoice/models/account_move.py
+++ b/account_edi_finvoice/models/account_move.py
@@ -46,6 +46,10 @@ class AccountMove(models.Model):
         elif not company_id:
             company_id = self.env.company.id
 
+        invoice = invoice.with_company(company_id).with_context(
+            default_move_type=invoice_type
+        )
+
         # region SellerPartyDetails
         spd = "SellerPartyDetails"
 
@@ -304,9 +308,6 @@ class AccountMove(models.Model):
         if partner_bank_id:
             invoice.partner_bank_id = partner_bank_id
         # endregion
-
-        if invoice.move_type == "in_invoice" and invoice_type == "in_refund":
-            invoice.action_switch_move_type()
 
         return invoice
 


### PR DESCRIPTION
## Summary

Wrap `invoice` with `with_company(company_id)` and `with_context(default_move_type=invoice_type)` after the company is resolved in `_import_finvoice`. Two effects:

- **Multi-company lookups**: Subsequent searches in the import (taxes, partner banks via `_retrieve_bank_account`, accounts) are scoped to the resolved `company_id` instead of `self.env.company`, which was a lurking bug for users importing into a non-default company.
- **Correct move_type at line creation**: `default_move_type` flows into the `account.move.line` creates lower in the function, so refunds (Finvoice `INV02`) get correct sign/account behavior up front.

Because `default_move_type` carries the right type into line creation, the trailing patch:

```python
if invoice.move_type == "in_invoice" and invoice_type == "in_refund":
    invoice.action_switch_move_type()
```

is redundant and removed. `action_switch_move_type` would also re-run line-level side effects (tax recomputation, account flips) which we don't need to trigger mid-import.

## Test plan

- [ ] Import a vendor Finvoice (INV01) into a non-default company in a multi-company DB; verify line account/tax resolve to that company's chart of accounts.
- [ ] Import a Finvoice credit note (INV02) and verify `move_type == "in_refund"` and lines are created with refund semantics directly (no post-hoc switch).
- [ ] Existing tests in `tests/test_account_move.py` continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
