### PR TITLE
[FIX] account_edi_finvoice: Don't overwrite partner data with empty Finvoice fields

### DIFF
--- a/account_edi_finvoice/__manifest__.py
+++ b/account_edi_finvoice/__manifest__.py
@@ -21,7 +21,7 @@
 {
     "name": "Import/Export invoices as Finvoice",
     "summary": "Import/Export Finvoice 3.0 invoices",
-    "version": "18.0.1.0.4",
+    "version": "18.0.1.0.5",
     "category": "Accounting",
     "website": "https://github.com/OCA/l10n-finland",
     "author": "Odoo Community Association (OCA), Futural",

--- a/account_edi_finvoice/models/account_move.py
+++ b/account_edi_finvoice/models/account_move.py
@@ -71,7 +71,6 @@ class AccountMove(models.Model):
 
         spad = "SellerPostalAddressDetails"
 
-        # TODO: Why are we always overwriting the values here?
         partner_vals = {
             "company_registry": business_code,
             "street": _find_value(f"./{spd}/{spad}/SellerStreetName"),
@@ -80,7 +79,10 @@ class AccountMove(models.Model):
         }
 
         if invoice.partner_id:
-            invoice.partner_id.write(partner_vals)
+            # Don't overwrite existing partner data with empty Finvoice fields
+            partner_write_vals = {k: v for k, v in partner_vals.items() if v}
+            if partner_write_vals:
+                invoice.partner_id.write(partner_write_vals)
         else:
             invoice.partner_id = self.env["res.partner"].create(
                 dict(


### PR DESCRIPTION
## Summary

When `_import_finvoice` matches an existing partner, the previous code unconditionally wrote every field collected from the seller address into that partner — including `False` values for any field the Finvoice happened to omit. Result: importing a Finvoice with a missing `<SellerStreetName>` would clear the existing partner's street.

Filter the dict to only non-empty values before writing. New partners are still created with the full dict (so missing fields remain `False`, which is fine for a fresh record).

This also resolves the standing `# TODO: Why are we always overwriting the values here?` comment.

## Test plan

- [ ] Existing partner with full address. Import a Finvoice that omits `<SellerStreetName>`. Existing street should be preserved.
- [ ] Existing partner with no street. Import a Finvoice that *does* include `<SellerStreetName>`. Street should be set.
- [ ] No matching partner. Import any valid Finvoice. New partner is created as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
