### PR TITLE
[FIX] account_edi_finvoice: Use InvoiceNumber as invoice.ref, preserve SellerReference

### DIFF
--- a/account_edi_finvoice/__manifest__.py
+++ b/account_edi_finvoice/__manifest__.py
@@ -21,7 +21,7 @@
 {
     "name": "Import/Export invoices as Finvoice",
     "summary": "Import/Export Finvoice 3.0 invoices",
-    "version": "18.0.1.0.4",
+    "version": "18.0.1.0.5",
     "category": "Accounting",
     "website": "https://github.com/OCA/l10n-finland",
     "author": "Odoo Community Association (OCA), Futural",

--- a/account_edi_finvoice/models/account_move.py
+++ b/account_edi_finvoice/models/account_move.py
@@ -96,9 +96,13 @@ class AccountMove(models.Model):
 
         # region InvoiceDetails
         ind = "InvoiceDetails"
-        invoice.ref = _find_value(f"./{ind}/SellerReferenceIdentifier") or _find_value(
-            f"./{ind}/InvoiceNumber"
-        )
+        # Per Finvoice 3.0, InvoiceNumber is the seller's invoice number;
+        # SellerReferenceIdentifier is the seller's own reference for the
+        # buyer (e.g. customer number). The former is the right value for
+        # invoice.ref.
+        invoice_number = _find_value(f"./{ind}/InvoiceNumber")
+        seller_ref = _find_value(f"./{ind}/SellerReferenceIdentifier")
+        invoice.ref = invoice_number or seller_ref
 
         invoice_date = _find_value(f"./{ind}/InvoiceDate")
         invoice.invoice_date = datetime.strptime(invoice_date, "%Y%m%d")
@@ -109,6 +113,10 @@ class AccountMove(models.Model):
             f"./{ind}/InvoiceFreeText",
             tree,
         )
+        if seller_ref and invoice_number and seller_ref != invoice_number:
+            invoice.narration = (invoice.narration or "") + _(
+                "\nSeller Reference: %s", seller_ref
+            )
 
         ptd = "PaymentTermsDetails"
         invoice.narration += edi_format._find_values_joined(


### PR DESCRIPTION
## Summary

`invoice.ref` is meant to hold the *seller's invoice number*, which in Finvoice 3.0 is `InvoiceNumber`. The current code preferred `SellerReferenceIdentifier` (the seller's reference *to the buyer* — commonly customer number, agreement number, order ID) and only fell back to `InvoiceNumber` if it was missing. As a result, on every Finvoice that filled both fields, `invoice.ref` ended up containing the customer number instead of the actual invoice number.

Reverse the preference, and when both fields are present and differ, append the seller reference to `narration` (`Seller Reference: …`) so the data is preserved.

## Test plan

- [ ] Import a Finvoice with `<InvoiceNumber>123456</InvoiceNumber>` and `<SellerReferenceIdentifier>CUST-42</SellerReferenceIdentifier>`. Verify `invoice.ref == "123456"` and narration contains `Seller Reference: CUST-42`.
- [ ] Import a Finvoice with only `<SellerReferenceIdentifier>` (no `<InvoiceNumber>`). Verify `invoice.ref` falls back to that value.
- [ ] Import a Finvoice with only `<InvoiceNumber>`. Verify `invoice.ref` is set, narration is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
