### PR TITLE
[IMP] account_edi_finvoice: Validate payment references and prefer authoritative source

### DIFF
--- a/account_edi_finvoice/__manifest__.py
+++ b/account_edi_finvoice/__manifest__.py
@@ -21,7 +21,7 @@
 {
     "name": "Import/Export invoices as Finvoice",
     "summary": "Import/Export Finvoice 3.0 invoices",
-    "version": "18.0.1.0.4",
+    "version": "18.0.1.0.5",
     "category": "Accounting",
     "website": "https://github.com/OCA/l10n-finland",
     "author": "Odoo Community Association (OCA), Futural",

--- a/account_edi_finvoice/models/account_move.py
+++ b/account_edi_finvoice/models/account_move.py
@@ -267,17 +267,28 @@ class AccountMove(models.Model):
 
         # region EpiDetails
         ede = "EpiDetails"
-        payment_reference = invoice.payment_reference = _find_value(
-            f"./{ede}/EpiIdentificationDetails/EpiReference"
-        )
+        epid = "EpiPaymentInstructionDetails"
 
+        # Collect candidates in order of authority. EpiRemittanceInfoIdentifier
+        # is the official Finvoice payment reference; EpiReference is a
+        # message identifier sometimes (incorrectly) used as a payment
+        # reference; SellersBuyerIdentifier is also occasionally repurposed.
+        ref_candidates = [
+            _find_value(f"./{ede}/{epid}/EpiRemittanceInfoIdentifier"),
+            _find_value(f"./{ede}/EpiIdentificationDetails/EpiReference"),
+            _find_value(f"./{ind}/SellersBuyerIdentifier"),
+        ]
+
+        # Prefer the first candidate that validates as a Finnish national
+        # reference or RF (ISO 11649) creditor reference; otherwise fall
+        # back to the first non-empty candidate so we still record what the
+        # sender provided.
+        payment_reference = next(
+            (r for r in ref_candidates if r and self._is_valid_payment_reference(r)),
+            None,
+        )
         if not payment_reference:
-            # Try to get payment reference from SellersBuyerIdentifier
-            # It's not officially for a payment reference,
-            # but is sometimes incorrectly used as it was
-            payment_reference = invoice.payment_reference = _find_value(
-                f"./{ind}/SellersBuyerIdentifier"
-            )
+            payment_reference = next((r for r in ref_candidates if r), None)
 
         invoice.payment_reference = payment_reference
 
@@ -328,3 +339,31 @@ class AccountMove(models.Model):
         )
 
         return partners or Partner
+
+    @staticmethod
+    def _is_valid_finnish_reference(ref):
+        """Validate a Finnish national payment reference (4-20 digits, 7-3-1 check)."""
+        if not ref.isdigit() or not (4 <= len(ref) <= 20):
+            return False
+        base = ref[:-1]
+        check_digit = ref[-1]
+        total = sum(
+            (7, 3, 1)[idx % 3] * int(val) for idx, val in enumerate(base[::-1])
+        )
+        return check_digit == str((10 - (total % 10)) % 10)
+
+    @staticmethod
+    def _is_valid_rf_reference(ref):
+        """Validate an RF creditor reference (ISO 11649, mod 97 check)."""
+        ref_upper = ref.upper()
+        if not re.match(r"^RF\d{2}\d{4,20}$", ref_upper):
+            return False
+        rearranged = ref_upper[4:] + ref_upper[:4]
+        numeric_str = "".join(
+            str(ord(c) - 55) if c.isalpha() else c for c in rearranged
+        )
+        return int(numeric_str) % 97 == 1
+
+    def _is_valid_payment_reference(self, ref):
+        """Check if ref is a valid Finnish national or RF payment reference."""
+        return self._is_valid_finnish_reference(ref) or self._is_valid_rf_reference(ref)


### PR DESCRIPTION
## Summary

Two improvements to payment reference handling in `_import_finvoice`:

### 1. Source preference

Per Finvoice 3.0, the payment reference belongs in `EpiDetails/EpiPaymentInstructionDetails/EpiRemittanceInfoIdentifier`. The element the previous code consulted, `EpiDetails/EpiIdentificationDetails/EpiReference`, is a *message* identifier — some senders fill it with a payment reference, but the official slot is `EpiRemittanceInfoIdentifier`.

New candidate order:
1. `EpiPaymentInstructionDetails/EpiRemittanceInfoIdentifier` (authoritative)
2. `EpiIdentificationDetails/EpiReference` (legacy / informal)
3. `InvoiceDetails/SellersBuyerIdentifier` (occasionally repurposed)

### 2. Validation

Three new helper methods:

- `_is_valid_finnish_reference(ref)` — Finnish national reference (4–20 digits, 7-3-1 weighted mod 10 check digit)
- `_is_valid_rf_reference(ref)` — RF creditor reference (ISO 11649, mod 97 check)
- `_is_valid_payment_reference(ref)` — combines both

The candidate selection prefers the first candidate that validates. When none validates, we fall back to the first non-empty candidate so a malformed reference is still recorded (better than silently dropping it).

### Why

A malformed `EpiReference` was previously preferred over a correct `EpiRemittanceInfoIdentifier`. After the fix, the spec-correct field is preferred, and validation lets us choose the right candidate when senders fill multiple slots inconsistently.

## Test plan

- [ ] Finvoice with a valid Finnish reference in `EpiRemittanceInfoIdentifier` and a different non-validating string in `EpiReference` — `invoice.payment_reference` matches the `EpiRemittanceInfoIdentifier` value.
- [ ] Finvoice with `RF18539007547034` in `EpiRemittanceInfoIdentifier` — accepted as valid RF.
- [ ] Finvoice with an invalid string `"REF/2024-001"` everywhere — `payment_reference` falls back to that string (recorded but not validated).
- [ ] Existing tests continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
