### PR TITLE
[IMP] account_edi_finvoice: Fall back to VatSpecificationDetails for missing row VAT rate

### DIFF
--- a/account_edi_finvoice/__manifest__.py
+++ b/account_edi_finvoice/__manifest__.py
@@ -21,7 +21,7 @@
 {
     "name": "Import/Export invoices as Finvoice",
     "summary": "Import/Export Finvoice 3.0 invoices",
-    "version": "18.0.1.0.4",
+    "version": "18.0.1.0.5",
     "category": "Accounting",
     "website": "https://github.com/OCA/l10n-finland",
     "author": "Odoo Community Association (OCA), Futural",

--- a/account_edi_finvoice/models/account_move.py
+++ b/account_edi_finvoice/models/account_move.py
@@ -122,6 +122,21 @@ class AccountMove(models.Model):
 
         # endregion
 
+        # region VatSpecificationDetails
+        # Build a base_amount -> vat_rate map from invoice-level VAT
+        # specifications, used as a fallback when an InvoiceRow lacks
+        # RowVatRatePercent. The row's RowVatExcludedAmount can then be
+        # matched against a VatBaseAmount to recover its VAT rate.
+        vat_spec_map = {}
+        for vat_spec in tree.xpath(f"./{ind}/VatSpecificationDetails", namespaces=ns):
+            base_amount = edi_format._to_float(
+                _find_value("./VatBaseAmount", vat_spec)
+            )
+            vat_rate = edi_format._to_float(_find_value("./VatRatePercent", vat_spec))
+            if base_amount:
+                vat_spec_map[base_amount] = vat_rate
+        # endregion
+
         # region InvoiceRows
         lines = tree.xpath("./InvoiceRow", namespaces=ns)
         line_number = 0
@@ -240,7 +255,17 @@ class AccountMove(models.Model):
             # Taxes
             # We are not using _retrieve_tax()
             # as it might return a tax with prices included
-            tax_amount = edi_format._to_float(_find_value("./RowVatRatePercent", line))
+            row_vat_rate = _find_value("./RowVatRatePercent", line)
+            if row_vat_rate is not None:
+                tax_amount = edi_format._to_float(row_vat_rate)
+            else:
+                # Row didn't carry a VAT rate; try the invoice-level
+                # VatSpecificationDetails by matching the row's excluded
+                # amount against a VatBaseAmount.
+                line_amount = edi_format._to_float(
+                    _find_value("./RowVatExcludedAmount", line)
+                )
+                tax_amount = vat_spec_map.get(line_amount)
             if tax_amount:
                 tax_domain = [
                     ("amount", "=", tax_amount),


### PR DESCRIPTION
## Summary

Some Finvoice 3.0 senders only declare VAT at the invoice-level `VatSpecificationDetails` summary, and leave `RowVatRatePercent` empty on individual `InvoiceRow` elements. The current row-tax lookup is `_find_value("./RowVatRatePercent", line)` only, so those rows end up untaxed and the resulting Odoo invoice doesn't reconcile against the sender's totals.

Build a `{VatBaseAmount: VatRatePercent}` map from `InvoiceDetails/VatSpecificationDetails` before iterating the rows. When a row lacks `RowVatRatePercent`, look up its `RowVatExcludedAmount` in the map to recover the rate.

## Test plan

- [ ] Import a Finvoice that uses per-row `RowVatRatePercent` only — behaviour unchanged.
- [ ] Import a Finvoice that omits `RowVatRatePercent` on rows but declares `VatSpecificationDetails` (e.g. `<VatBaseAmount>100,00</VatBaseAmount><VatRatePercent>25,5</VatRatePercent>`) — rows with `RowVatExcludedAmount=100,00` get the 25.5% tax applied.
- [ ] Import a Finvoice with neither — rows still come in untaxed (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
