### PR TITLE
[IMP] account_edi_finvoice: Reconcile imported lines against RowVatExcludedAmount

### DIFF
--- a/account_edi_finvoice/__manifest__.py
+++ b/account_edi_finvoice/__manifest__.py
@@ -21,7 +21,7 @@
 {
     "name": "Import/Export invoices as Finvoice",
     "summary": "Import/Export Finvoice 3.0 invoices",
-    "version": "18.0.1.0.4",
+    "version": "18.0.1.0.5",
     "category": "Accounting",
     "website": "https://github.com/OCA/l10n-finland",
     "author": "Odoo Community Association (OCA), Futural",

--- a/account_edi_finvoice/models/account_move.py
+++ b/account_edi_finvoice/models/account_move.py
@@ -147,10 +147,12 @@ class AccountMove(models.Model):
             # ean_code = _find_value("./EanCode", line)
 
             # Construct a unit price
-            quantity = 1
+            quantity = (
+                edi_format._to_float(_find_value("./InvoicedQuantity", line)) or 1
+            )
 
             # Try to find UnitPriceAmount
-            price_unit = False
+            price_unit = _find_value("./UnitPriceAmount", line)
 
             if not price_unit or edi_format._to_float(price_unit) == 0:
                 # Didn't find UnitPriceAmount. Try RowVatExcludedAmount
@@ -161,6 +163,43 @@ class AccountMove(models.Model):
 
             if not price_unit:
                 price_unit = 0
+
+            # Reconcile against the row's authoritative excluded total when
+            # the naive quantity x round(unit_price, 2) x (1 - discount) does
+            # not produce it. Three known causes:
+            # - Per-N pricing (e.g. price quoted per 100 pieces while
+            #   InvoicedQuantity is in pieces) silently inflates the line.
+            # - Per-line vs per-invoice VAT rounding can drift the row total
+            #   by a cent or two.
+            # - UnitPriceAmount may carry more than two decimals; storing it
+            #   in price_unit (2-decimal precision) loses cents on quantities
+            #   that don't divide evenly.
+            # When the reconstruction does not match RowVatExcludedAmount,
+            # collapse to (qty=1, price_unit=row_excl, discount=0) so the
+            # imported subtotal matches the source. The original pricing is
+            # kept in the line description for traceability. Discount must be
+            # factored in because RowVatExcludedAmount already reflects it.
+            row_vat_excluded_raw = _find_value("./RowVatExcludedAmount", line)
+            discount = (
+                edi_format._to_float(_find_value("./RowDiscountPercent", line)) or 0
+            )
+            reconciliation_note = ""
+            if row_vat_excluded_raw:
+                row_vat_excluded = edi_format._to_float(row_vat_excluded_raw)
+                current_price_unit = edi_format._to_float(price_unit) or 0
+                discount_factor = 1 - discount / 100
+                stored_subtotal = round(
+                    round(current_price_unit, 2) * quantity * discount_factor, 2
+                )
+                if round(stored_subtotal - row_vat_excluded, 2) != 0:
+                    currency_name = invoice.currency_id.name or ""
+                    reconciliation_note = (
+                        f"({quantity:g} × {current_price_unit:g} {currency_name}"
+                        + (f" - {discount:g}%)" if discount else ")")
+                    )
+                    quantity = 1
+                    price_unit = row_vat_excluded
+                    discount = 0
 
             if article_name:
                 _logger.debug(f"Importing '{article_name}'")
@@ -208,6 +247,9 @@ class AccountMove(models.Model):
             if article_name != article_free_text:
                 line_name += "\n" + article_free_text
 
+            if reconciliation_note:
+                line_name = (line_name + "\n" + reconciliation_note).lstrip("\n")
+
             line_values["name"] = line_name
 
             if not article_name and not default_code:
@@ -233,9 +275,7 @@ class AccountMove(models.Model):
 
             line_values["price_unit"] = edi_format._to_float(price_unit)
 
-            line_values["discount"] = edi_format._to_float(
-                _find_value("./RowDiscountPercent", line)
-            )
+            line_values["discount"] = discount
 
             # Taxes
             # We are not using _retrieve_tax()


### PR DESCRIPTION
## Summary

Today the line-import code unconditionally collapses every Finvoice row to `quantity=1` with `price_unit = RowVatExcludedAmount / 1`. This avoids rounding artefacts but throws away the seller's quantity and unit price, which is information users want to see on the imported bill.

This PR restores `InvoicedQuantity` × `UnitPriceAmount` parsing and adds a reconciliation pass that only collapses when the naive reconstruction doesn't match the row's authoritative `RowVatExcludedAmount`.

### What goes wrong without reconciliation

Three real cases observed from Finnish senders:

1. **Per-N pricing** — `UnitPriceAmount` is quoted per 100 pieces while `InvoicedQuantity` carries the piece count. `qty × unit_price` over-counts 100×.
2. **Per-line VAT rounding drift** — a couple of senders round VAT per row differently than Odoo does per-invoice; the imported subtotal would drift by a cent vs. `RowVatExcludedAmount`.
3. **`price_unit` precision loss** — `UnitPriceAmount` can carry 4–5 decimals; the Odoo `price_unit` field stores 2. `127.49 / 40 = 3.18725` is stored as `3.19`, line total becomes `127.60` instead of `127.49`.

### Algorithm

```python
qty = InvoicedQuantity or 1
unit = UnitPriceAmount  # falls back to RowVatExcludedAmount/qty if missing
discount = RowDiscountPercent or 0
stored = round(round(unit, 2) * qty * (1 - discount/100), 2)
if stored != RowVatExcludedAmount:
    # original (qty, unit, discount) preserved in name
    qty, unit, discount = 1, RowVatExcludedAmount, 0
```

Discount must be factored in because `RowVatExcludedAmount` already reflects it.

When the collapse triggers, the original pricing is appended to the line name as e.g. `(40 × 3.18725 EUR)` or `(10 × 19,90 EUR - 10%)`, so users can still see what the seller sent.

## Test plan

- [ ] Import a normal Finvoice (e.g. `qty=2, unit=10.00`, `RowVatExcludedAmount=20.00`) — line stored as qty=2, unit=10.00, no extra note in name.
- [ ] Import a per-100-priced row: `qty=40, unit=350.00, RowVatExcludedAmount=140.00`. Line stored as qty=1, unit=140.00; name contains `(40 × 350 EUR)`.
- [ ] Import a row with awkward unit price: `qty=40, unit=3.18725, RowVatExcludedAmount=127.49`. Line stored as qty=1, unit=127.49; name contains `(40 × 3.18725 EUR)`.
- [ ] Import a row with `RowDiscountPercent=10` where `qty × unit × 0.9 == RowVatExcludedAmount`. No collapse; discount preserved on the line.
- [ ] Import a row with no `RowVatExcludedAmount`. Imported with raw qty/unit/discount as before.

## Notes

- This is a precondition for PR-J (`SubInvoiceRow` handling) and works correctly alongside PR-K (#91) — the warning fields will now reconcile against more accurate line totals.
- 6 cleanup/correctness PRs already merged in this campaign; this is the keystone for the line-handling stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
