### PR TITLE
[IMP] account_edi_finvoice: Match imported lines to existing products

### DIFF
--- a/account_edi_finvoice/__manifest__.py
+++ b/account_edi_finvoice/__manifest__.py
@@ -21,7 +21,7 @@
 {
     "name": "Import/Export invoices as Finvoice",
     "summary": "Import/Export Finvoice 3.0 invoices",
-    "version": "18.0.1.0.4",
+    "version": "18.0.1.0.5",
     "category": "Accounting",
     "website": "https://github.com/OCA/l10n-finland",
     "author": "Odoo Community Association (OCA), Futural",

--- a/account_edi_finvoice/models/account_move.py
+++ b/account_edi_finvoice/models/account_move.py
@@ -173,29 +173,25 @@ class AccountMove(models.Model):
                 _logger.debug("Skipping a zero line due to a long invoice")
                 continue
 
+            # Try to find a matching product by default code or article name
+            # TODO: an option to auto-create missing products
             product_id = False
-            line_name = ""
+            if default_code or article_name:
+                product_id = self.env["product.product"]._retrieve_product(
+                    default_code=default_code,
+                    name=article_name,
+                )
 
-            # if default_code or ean_code or article_name:
-            #     product_id = self.env["product.product"]._retrieve_product(
-            #         default_code=default_code,
-            #         name=article_name,
-            #         barcode=ean_code,
-            #     )
-            # else:
-            #     product_id = self.env["product.product"]
-            # # TODO: An option to auto-create products
-            #
-            # if product_id:
-            #     line_values["product_id"] = product_id.id
-            #
-            # if product_id:
-            #     accounts = product_id.product_tmpl_id._get_product_accounts()
-            #
-            #     if invoice_type == "in_invoice":
-            #         line_values["account_id"] = accounts["expense"].id
-            #     elif invoice_type == "out_invoice":
-            #         line_values["account_id"] = accounts["income"].id
+            if product_id:
+                line_values["product_id"] = product_id.id
+
+                accounts = product_id.product_tmpl_id._get_product_accounts()
+                if invoice_type == "in_invoice":
+                    line_values["account_id"] = accounts["expense"].id
+                elif invoice_type == "out_invoice":
+                    line_values["account_id"] = accounts["income"].id
+
+            line_name = ""
 
             # Construct a line name, if product is not found
 


### PR DESCRIPTION
## Summary

The product-matching block in `_import_finvoice` has been commented out for years (`TODO: An option to auto-create products`). Re-enable it for the existing-product case only:

- Look up products by `default_code` (`BuyerArticleIdentifier` or `ArticleIdentifier`) or `article_name`.
- When found, link the line to the product (`line_values["product_id"]`) and pre-fill the line's `account_id` from the product template's income/expense default, using `invoice_type` to choose.
- Auto-creating missing products is **not** in scope; the TODO comment is preserved.

The barcode/`EanCode` parameter to `_retrieve_product` is intentionally left out of this PR and added in a follow-up — keeping this change small and orthogonal to the EanCode parsing work.

## Test plan

- [ ] Import a Finvoice where every `BuyerArticleIdentifier` matches an existing `product.product.default_code`. Lines link to those products and pick up the right income/expense account.
- [ ] Import a Finvoice with no matching products (random article names). Lines come in without `product_id`, name still constructed from article fields. No regression vs. before.
- [ ] Vendor bill (in_invoice): the linked line gets the product's expense account.
- [ ] Customer invoice (out_invoice): the linked line gets the product's income account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
