### PR TITLE
[IMP] account_edi_finvoice: Import VAT-included pricing (UnitPriceVatIncludedAmount, RowAmount)

### DIFF
--- a/account_edi_finvoice/__manifest__.py
+++ b/account_edi_finvoice/__manifest__.py
@@ -21,7 +21,7 @@
 {
     "name": "Import/Export invoices as Finvoice",
     "summary": "Import/Export Finvoice 3.0 invoices",
-    "version": "18.0.1.0.6",
+    "version": "18.0.1.0.7",
     "category": "Accounting",
     "website": "https://github.com/OCA/l10n-finland",
     "author": "Odoo Community Association (OCA), Futural",

--- a/account_edi_finvoice/__manifest__.py
+++ b/account_edi_finvoice/__manifest__.py
@@ -21,7 +21,7 @@
 {
     "name": "Import/Export invoices as Finvoice",
     "summary": "Import/Export Finvoice 3.0 invoices",
-    "version": "18.0.1.0.5",
+    "version": "18.0.1.0.6",
     "category": "Accounting",
     "website": "https://github.com/OCA/l10n-finland",
     "author": "Odoo Community Association (OCA), Futural",

--- a/account_edi_finvoice/__manifest__.py
+++ b/account_edi_finvoice/__manifest__.py
@@ -21,7 +21,7 @@
 {
     "name": "Import/Export invoices as Finvoice",
     "summary": "Import/Export Finvoice 3.0 invoices",
-    "version": "18.0.1.0.4",
+    "version": "18.0.1.0.5",
     "category": "Accounting",
     "website": "https://github.com/OCA/l10n-finland",
     "author": "Odoo Community Association (OCA), Futural",

--- a/account_edi_finvoice/models/account_move.py
+++ b/account_edi_finvoice/models/account_move.py
@@ -146,9 +146,12 @@ class AccountMove(models.Model):
 
             # ean_code = _find_value("./EanCode", line)
 
-            # Construct a unit price
+            # Construct a unit price. InvoicedQuantity is the canonical
+            # element; some senders only fill DeliveredQuantity.
             quantity = (
-                edi_format._to_float(_find_value("./InvoicedQuantity", line)) or 1
+                edi_format._to_float(_find_value("./InvoicedQuantity", line))
+                or edi_format._to_float(_find_value("./DeliveredQuantity", line))
+                or 1
             )
 
             # Try to find UnitPriceAmount
@@ -263,6 +266,10 @@ class AccountMove(models.Model):
             unit_code = edi_format._find_attribute(
                 "./InvoicedQuantity", line, "QuantityUnitCode"
             )
+            if not unit_code:
+                unit_code = edi_format._find_attribute(
+                    "./DeliveredQuantity", line, "QuantityUnitCode"
+                )
             if product_id and unit_code:
                 uom = self.env["uom.uom"].search(
                     [("name", "ilike", unit_code)], limit=1

--- a/account_edi_finvoice/models/account_move.py
+++ b/account_edi_finvoice/models/account_move.py
@@ -147,10 +147,12 @@ class AccountMove(models.Model):
             # ean_code = _find_value("./EanCode", line)
 
             # Construct a unit price
-            quantity = 1
+            quantity = (
+                edi_format._to_float(_find_value("./InvoicedQuantity", line)) or 1
+            )
 
             # Try to find UnitPriceAmount
-            price_unit = False
+            price_unit = _find_value("./UnitPriceAmount", line)
 
             if not price_unit or edi_format._to_float(price_unit) == 0:
                 # Didn't find UnitPriceAmount. Try RowVatExcludedAmount
@@ -161,6 +163,43 @@ class AccountMove(models.Model):
 
             if not price_unit:
                 price_unit = 0
+
+            # Reconcile against the row's authoritative excluded total when
+            # the naive quantity x round(unit_price, 2) x (1 - discount) does
+            # not produce it. Three known causes:
+            # - Per-N pricing (e.g. price quoted per 100 pieces while
+            #   InvoicedQuantity is in pieces) silently inflates the line.
+            # - Per-line vs per-invoice VAT rounding can drift the row total
+            #   by a cent or two.
+            # - UnitPriceAmount may carry more than two decimals; storing it
+            #   in price_unit (2-decimal precision) loses cents on quantities
+            #   that don't divide evenly.
+            # When the reconstruction does not match RowVatExcludedAmount,
+            # collapse to (qty=1, price_unit=row_excl, discount=0) so the
+            # imported subtotal matches the source. The original pricing is
+            # kept in the line description for traceability. Discount must be
+            # factored in because RowVatExcludedAmount already reflects it.
+            row_vat_excluded_raw = _find_value("./RowVatExcludedAmount", line)
+            discount = (
+                edi_format._to_float(_find_value("./RowDiscountPercent", line)) or 0
+            )
+            reconciliation_note = ""
+            if row_vat_excluded_raw:
+                row_vat_excluded = edi_format._to_float(row_vat_excluded_raw)
+                current_price_unit = edi_format._to_float(price_unit) or 0
+                discount_factor = 1 - discount / 100
+                stored_subtotal = round(
+                    round(current_price_unit, 2) * quantity * discount_factor, 2
+                )
+                if round(stored_subtotal - row_vat_excluded, 2) != 0:
+                    currency_name = invoice.currency_id.name or ""
+                    reconciliation_note = (
+                        f"({quantity:g} × {current_price_unit:g} {currency_name}"
+                        + (f" - {discount:g}%)" if discount else ")")
+                    )
+                    quantity = 1
+                    price_unit = row_vat_excluded
+                    discount = 0
 
             if article_name:
                 _logger.debug(f"Importing '{article_name}'")
@@ -208,6 +247,9 @@ class AccountMove(models.Model):
             if article_name != article_free_text:
                 line_name += "\n" + article_free_text
 
+            if reconciliation_note:
+                line_name = (line_name + "\n" + reconciliation_note).lstrip("\n")
+
             line_values["name"] = line_name
 
             if not article_name and not default_code:
@@ -233,9 +275,7 @@ class AccountMove(models.Model):
 
             line_values["price_unit"] = edi_format._to_float(price_unit)
 
-            line_values["discount"] = edi_format._to_float(
-                _find_value("./RowDiscountPercent", line)
-            )
+            line_values["discount"] = discount
 
             # Taxes
             # We are not using _retrieve_tax()

--- a/account_edi_finvoice/models/account_move.py
+++ b/account_edi_finvoice/models/account_move.py
@@ -154,8 +154,9 @@ class AccountMove(models.Model):
                 or 1
             )
 
-            # Try to find UnitPriceAmount
+            # Try to find UnitPriceAmount (VAT-excluded)
             price_unit = _find_value("./UnitPriceAmount", line)
+            price_include = False
 
             if not price_unit or edi_format._to_float(price_unit) == 0:
                 # Didn't find UnitPriceAmount. Try RowVatExcludedAmount
@@ -163,6 +164,18 @@ class AccountMove(models.Model):
                 price_subtotal = edi_format._to_float(price_subtotal)
                 if price_subtotal:
                     price_unit = price_subtotal / quantity
+
+            if not price_unit or edi_format._to_float(price_unit) == 0:
+                # Still no price. Try VAT-included amounts
+                # (e.g. FedEx invoices that omit the excluded fields).
+                price_unit_incl = _find_value("./UnitPriceVatIncludedAmount", line)
+                if not price_unit_incl or edi_format._to_float(price_unit_incl) == 0:
+                    row_amount = edi_format._to_float(_find_value("./RowAmount", line))
+                    if row_amount:
+                        price_unit_incl = row_amount / quantity
+                if price_unit_incl and edi_format._to_float(price_unit_incl) != 0:
+                    price_unit = price_unit_incl
+                    price_include = True
 
             if not price_unit:
                 price_unit = 0
@@ -292,14 +305,34 @@ class AccountMove(models.Model):
                 tax_domain = [
                     ("amount", "=", tax_amount),
                     ("type_tax_use", "=", invoice.journal_id.type),
-                    # The subtotal will be saved as untaxed amount
-                    ("price_include", "=", False),
+                    ("price_include", "=", price_include),
                     ("company_id", "=", company_id),
                 ]
 
                 tax = self.env["account.tax"].search(
                     tax_domain, order="sequence ASC", limit=1
                 )
+
+                if not tax and price_include:
+                    # No price-included tax exists. Fall back to a
+                    # price-excluded tax and reverse-calculate the unit
+                    # price so the imported subtotal still matches.
+                    tax = self.env["account.tax"].search(
+                        [
+                            ("amount", "=", tax_amount),
+                            ("type_tax_use", "=", invoice.journal_id.type),
+                            ("price_include", "=", False),
+                            ("company_id", "=", company_id),
+                        ],
+                        order="sequence ASC",
+                        limit=1,
+                    )
+                    if tax and tax_amount:
+                        price_unit = edi_format._to_float(price_unit) / (
+                            1 + tax_amount / 100
+                        )
+                        line_values["price_unit"] = price_unit
+                        price_include = False
 
                 if not tax:
                     raise ValidationError(_(f"Could not find a tax for {tax_amount}"))


### PR DESCRIPTION
## Summary

Some Finvoice senders — FedEx is the canonical example — only populate the **VAT-included** pricing fields and leave `UnitPriceAmount` and `RowVatExcludedAmount` empty. Those rows currently import with `price_unit=0` and no usable subtotal.

Add a third pricing fallback after the existing two:

1. `UnitPriceAmount` (existing — VAT-excluded unit price)
2. `RowVatExcludedAmount / quantity` (existing — VAT-excluded subtotal divided by qty)
3. **New**: `UnitPriceVatIncludedAmount` or `RowAmount / quantity`, with `price_include=True`

The tax lookup now uses the `price_include` flag the price was sourced under, instead of always searching with `price_include=False`.

### Tax fallback

If no `price_include=True` tax exists at the row's VAT rate (common in chart-of-accounts that only define excluded-price taxes), fall back to a `price_include=False` tax of the same rate and reverse-calculate `price_unit /= (1 + rate/100)`. The imported subtotal still matches the source row, just stored as excluded price + tax instead of included price.

## Dependency

**Depends on [#92](https://github.com/OCA/l10n-finland/pull/92) and [#95](https://github.com/OCA/l10n-finland/pull/95)** — extends the price-resolution chain that #92 restored and #95 augmented. The reconciliation block from #92 is unaffected because it's gated on `RowVatExcludedAmount` being present, which by definition is empty when this new branch triggers.

## Test plan

- [ ] Import a Finvoice row with `<UnitPriceVatIncludedAmount>12,40</UnitPriceVatIncludedAmount>`, no `UnitPriceAmount`, no `RowVatExcludedAmount`, and `<RowVatRatePercent>24</RowVatRatePercent>`. With a 24% price-included tax in the chart: line stored at 12.40 with that tax. With only 24% price-excluded: line stored at 10.00 with the excluded tax (10 + 2.40 VAT = 12.40 reconciles).
- [ ] Import a row with only `<RowAmount>62,00</RowAmount>` and `<InvoicedQuantity>5</InvoicedQuantity>`. Line stored at 12.40/unit with appropriate handling.
- [ ] Existing rows with VAT-excluded fields are unaffected (both new branches stay false).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
